### PR TITLE
fix: handle errors caused by closing the importer

### DIFF
--- a/projects/angular-adapter/src/lib/flatfile-button.component.ts
+++ b/projects/angular-adapter/src/lib/flatfile-button.component.ts
@@ -82,7 +82,8 @@ export class FlatfileButtonComponent implements OnInit, OnDestroy {
     try {
       this.flatfileImporter?.close();
     } catch {
-      // do nothing to prevent any errors
+      // If the Importer has yet to be opened, calling `close` will throw an error,
+      // which can cause things like route changes to break.
     }
   }
 

--- a/projects/angular-adapter/src/lib/flatfile-button.component.ts
+++ b/projects/angular-adapter/src/lib/flatfile-button.component.ts
@@ -79,7 +79,11 @@ export class FlatfileButtonComponent implements OnInit, OnDestroy {
   }
 
   public ngOnDestroy(): void {
-    this.flatfileImporter.close();
+    try {
+      this.flatfileImporter?.close();
+    } catch {
+      // do nothing to prevent any errors
+    }
   }
 
   public launch(): void {


### PR DESCRIPTION
Addresses errors that occur when disposing of the component, namely when either the `flatFileImporter` has yet to be initialized or `open()` has yet to be called.

Fixes #21.